### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 Gaggiuino MCP Server
 This is a lightweight Model Context Protocol (MCP) server built for [Gaggiuino](https://github.com/Zer0-bit/gaggiuino), the open-source espresso machine controller for the Gaggia Classic. It is designed to integrate easily AI clients that want to display or analyze data from the Gaggiuino system in real time.
 
+<a href="https://glama.ai/mcp/servers/@AndrewKlement/gaggiuino-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@AndrewKlement/gaggiuino-mcp/badge" alt="Gaggiuino Server MCP server" />
+</a>
+
 ## The MCP server exposes a simple HTTP API that allows connected clients to:
 
 - Retrieve the current machine status


### PR DESCRIPTION
This PR adds a badge for the [Gaggiuino MCP Server](https://glama.ai/mcp/servers/@AndrewKlement/gaggiuino-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@AndrewKlement/gaggiuino-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@AndrewKlement/gaggiuino-mcp/badge" alt="Gaggiuino Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.